### PR TITLE
Fix ambiguous error when TestCase is not able to instantiate

### DIFF
--- a/nose_allure/__init__.py
+++ b/nose_allure/__init__.py
@@ -102,7 +102,7 @@ class Allure(Plugin):
         else:
             method = getattr(test.test, test.test._testMethodName)
 
-        hierarchy = ".".join([filter(None, test.address()[1:]))
+        hierarchy = ".".join(filter(None, test.address()[1:]))
 
         self.allure.impl.start_case(hierarchy, description=method.__doc__,
                                     labels=get_labels(method))


### PR DESCRIPTION
To recreate this issue:

Create a virtualenv, then `pip install nose-allure-plugin`.

Run the following: `nosetests --with-allure --logdir . does_not_exist.py`

The error message you will receive is cryptic:

    Traceback (most recent call last):
      File "/box/python/lib/python2.7/site-packages/nose/case.py", line 133, in run
        self.runTest(result)
      File "/box/python/lib/python2.7/site-packages/nose/case.py", line 151, in runTest
        test(result)
      File "/box/python/lib/python2.7/unittest/case.py", line 393, in __call__
        return self.run(*args, **kwds)
      File "/box/python/lib/python2.7/unittest/case.py", line 304, in run
        result.startTest(self)
      File "/box/python/lib/python2.7/site-packages/nose/proxy.py", line 169, in startTest
        self.plugins.startTest(self.test)
      File "/box/python/lib/python2.7/site-packages/nose/plugins/manager.py", line 99, in __call__
        return self.call(*arg, **kw)
      File "/box/python/lib/python2.7/site-packages/nose/plugins/manager.py", line 167, in simple
        result = meth(*arg, **kw)
      File "/box/python/lib/python2.7/site-packages/nose_allure/__init__.py", line 113, in startTest
        hierarchy = ".".join(test.address()[1:])
    TypeError: sequence item 1: expected string, NoneType found

Running the equivalent without nose-allure-plugin enabled generates a logical error message:

`nosetests does_not_exist.py`

```
Traceback (most recent call last):
  File "/Users/pittmank/.venvs/allure_test/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/pittmank/.venvs/allure_test/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/pittmank/.venvs/allure_test/lib/python2.7/site-packages/nose/importer.py", line 79, in importFromDir
    fh, filename, desc = find_module(part, path)
ImportError: No module named does_not_exist
```


Well, you might say to yourself, don't run a test that doesn't exist. Ok, that's fair enough - but it works as a minimal example of the error message I'm referring to.

A more concrete example might be something like this:

```
# test.py
import unittest
import nose

config = {
    'foo': 1,
    'bar': 2,
}

class TestSomeStuff(unittest.TestCase):
      _setup_var_ = config['baz'] # KeyError
     def test_sanity(self):
        self.assertTrue(True)
```

Given the above file, running `nosetest --with-allure --logdir . test.py` will generate the same strange error, and obfuscate the actual error.


Since the error message we receive from nose-allure-plugin is complaining about trying to create a string from a list that contains a None value, my duct-tape solution was to simply filter the list and remove all elements that evaluate to False (like None).

Calling filter(None, source_list) will evaluate each element of source_list as a boolean, and discard elements that evaluate to false. A more explicit approach might be to use a lambda for the filter clause: `filter(lambda el: el is not None, test.address()[1:])`

Either works.

If someone could let me know if there's a better way to avoid this error altogether, instead of just filtering out the `None` values, I'd be interested to hear about it!